### PR TITLE
TeX実習：雑多な修正

### DIFF
--- a/contents/tex/tex_practice.md
+++ b/contents/tex/tex_practice.md
@@ -25,7 +25,7 @@ PDFファイルなどはダウンロードした後にPDFビューアを用い�
 - [TeX Live のインストール](tex_inst.pdf) に沿って TeX Live 2016 を導入する．
 
 ## 実習
-インストールが済んだら，各自のレベルに合わせて [TeX 実習](tex_practice.pdf) に沿って実習を進めること．
+インストールが済んだら，各自のレベルに合わせて [TeX 実習 (tex_practice.pdf)](tex_practice.pdf) に沿って実習を進めること．
 
 - 昨年度の受講生の中間レポートを添削した際の講評が，
   [tensaku.pdf](tensaku.pdf)としてまとめてある．

--- a/contents/tex/tex_practice.tex
+++ b/contents/tex/tex_practice.tex
@@ -1591,7 +1591,7 @@ BoundingBoxが格納された\FNAME{fig1.xbb},~\FNAME{fig2.xbb}が生成され�
 \Xy-pic は文法が独特であり，慣れるのはなかなか大変である．
 詳しい使い方は，
 \begin{quote}
-Kristoffer~H. Rose. \textit{Xy-pic User's Guide}, 2013.
+Kristoffer~H. Rose. \textit{\Xy-pic User's Guide}, 2013.
 \url{http://mirrors.ctan.org/macros/generic/diagrams/xypic/doc/xyguide.pdf}.\\
 または，\FNAME{C:\texlive\2016\texmf-dist\doc\generic\xypic\xyguide.pdf}
 \end{quote}
@@ -1615,7 +1615,7 @@ Kristoffer~H. Rose. \textit{Xy-pic User's Guide}, 2013.
 \begin{lstlisting}
 \usepackage[all]{xy}
 \end{lstlisting}
-と入力することでXy-picを読み込んだ上で，
+と入力することで\Xy-picを読み込んだ上で，
 \begin{lstlisting}
  \[
   \xymatrix{

--- a/contents/tex/tex_practice.tex
+++ b/contents/tex/tex_practice.tex
@@ -540,11 +540,29 @@ $f(x)=0$となる$0<x<1$が存在する．
 1行目左は$s\cdot i\cdot n\cdot x$の意味に解釈されてしまう．
 1行目右も空白が足りない．
 なお，\cs{sin}のような専用命令が予め準備されていない状況もあるが，その場合は定義すれば良い．
-例えば，\cs{dom}を使いたいならば
+例えば，\cs{dom}を使いたいならばプリアンブルに
 \begin{quote}
   \verb@\newcommand\dom{\mathop{\mathrm{dom}}}@
 \end{quote}
-をプリアンブルに記述すれば良い．
+と記述するか，あるいは\PKG{amsmath}パッケージ\footnote{%
+アメリカ数学会による，数式組版の機能を
+拡張するパッケージ．数学科の諸君なら，\PKG{amssymb}パッケージと共に
+いつでも読み込むようにしておこう．
+基本的なマニュアルは，%
+\href{http://www.ring.gr.jp/pub/text/CTAN/macros/latex/required/amslatex/math/amsldoc.pdf}%
+{User's Guide for the \texttt{amsmath} Package}．
+実習用マシンにも
+\FNAME{C:￥texlive￥2016￥texmf-dist￥doc￥latex￥amslatex￥math￥amsldoc.pdf}にある．
+}を読み込んだ上で
+\begin{quote}
+  \verb@\DeclareMathOperator{\dom}{dom}@
+\end{quote}
+と記述すれば良い\footnote{%
+別行立て数式の中で添字の位置を$\operatorname{Res}_{z=a}$ではなく$\displaystyle\operatorname*{Res}_{z=a}$のように真下にしたい場合は，
+スター\texttt{*}付きの\cs{DeclareMathOperator*}を使う．
+例：\texttt{\cs{DeclareMathOperator*}\{\cs{Residue}\}\{Res\}}
+}．
+いちいち命令を定義したくない場合は，\cs{operatorname}命令を使って数式中に直接\verb@\operatorname{dom}@と書くこともできる．
 
 \medskip
 
@@ -559,15 +577,7 @@ $f(x)=0$となる$0<x<1$が存在する．
 正：$f(a,b,\ldots,z)$
 \end{LTXexample}
 
-\PKG{amsmath}パッケージ\footnote{アメリカ数学会による，数式組版の機能を
-拡張するパッケージ．数学科の諸君なら，\PKG{amssymb}パッケージと共に
-いつでも読み込むようにしておこう．
-基本的なマニュアルは，%
-\href{http://www.ring.gr.jp/pub/text/CTAN/macros/latex/required/amslatex/math/amsldoc.pdf}%
-{User's Guide for the \texttt{amsmath} Package}．
-実習用マシンにも
-\FNAME{C:￥texlive￥2016￥texmf-dist￥doc￥latex￥amslatex￥math￥amsldoc.pdf}にある．
-}を読み込んでいるなら，\cs{dotsb}などの命令も参照．
+\PKG{amsmath}パッケージを読み込んでいるなら，\cs{dotsb}などの命令も参照．
 なお，\LaTeX で標準で用意されている\cs{dots}命令だが，
 \PKG{amsmath}パッケージを読み込んでいるかで動作が変わり，
 \begin{itemize}

--- a/contents/tex/tex_practice.tex
+++ b/contents/tex/tex_practice.tex
@@ -1472,16 +1472,10 @@ LaTeX Warning: Label(s) may have changed. Rerun to get cross-references right.
 \end{curve}
 
 \medskip
-この症状を治すには，従来は
-\begin{lstlisting}
-  \usepackage{atbegshi}
-  \AtBeginShipoutFirst{\special{pdf:tounicode 90ms-RKSJ-UCS2}}
-\end{lstlisting}
-なとどいう「オマジナイ」を書く必要があった．しかし，
-今では八登崇之氏による\href{http://www.ctan.org/tex-archive/language/japanese/pxjahyper}%
+この症状を治すには，八登崇之氏による\href{http://www.ctan.org/tex-archive/language/japanese/pxjahyper}%
 {\PKG{pxjahyper}パッケージ}\footnote{%
 マニュアルは実習用マシンの\FNAME{C:￥texlive￥2016￥texmf-dist￥doc￥platex￥pxjahyper￥pxjahyper.pdf}にもある．
-}を読み込むだけで良くなった．
+}を，\PKG{hyperref}パッケージの\emph{後に}読み込む．
 
 というわけで，\FNAME{hytest.tex}のプリアンブルを
 \begin{lstlisting}[xleftmargin=3\zw]


### PR DESCRIPTION
いくつか雑多な修正です。

conflictを起こすと嫌なので、tex_practice.pdfへの変更はコミットには含めていません。
若月さんが他の変更をしたついでに一緒にtex_practice.pdfを再生成することを期待しています。

変更内容：

* hyperrefについて「オマジナイ」の記述を削除

pxjahyperパッケージが登場して既に何年も経っている．
単に「pxjahyperを使えば良い」と書いておけば良いだろう．

* Xy-picの表記で \Xy コマンドを使っていない箇所があるのを修正した

* \DeclareMathOperator の紹介を追加

せっかく関数名の命令を定義する方法を紹介するのに \DeclareMathOperator を紹介しないのは片手落ちだと考えられる．

* tex_practice.md: tex_practice.pdf へのリンクでファイル名を明示する

リンク元のページも「TeX実習」なので，リンク文字列が同じ「TeX実習」だと一瞬面食らう．
リンク先が現在のページと異なるPDFファイルであることがわかる配慮があると良いだろう．