### PR TITLE
ECMAScript入門・Haskell入門のリンクを張り替え

### DIFF
--- a/contents/script/top.md
+++ b/contents/script/top.md
@@ -8,9 +8,9 @@
 * [Perl 入門](https://sites.google.com/a/utmsks.net/material/home/perl2013) (2013 年度作成)
 * [Python 入門](https://sites.google.com/a/utmsks.net/material/home/python2013) (2013 年度作成, 2015 年度改訂)
 * [Python で遊ぼう](https://sites.google.com/a/utmsks.net/material/home/python_asobou) (2016 年度作成)
-* [JavaScript 入門 with Node.js](https://sites.google.com/a/utmsks.net/material/home/language-list/ecmascript) (2017 年度作成)
+* [JavaScript 入門 with Node.js](https://minoki.github.io/ks-material/ecmascript/) (2017 年度作成)
 * [Lua 入門](https://sites.google.com/a/utmsks.net/material/home/lua-intro) (2013 年度作成, 2015 年度改訂)
-* [Haskell 入門](https://sites.google.com/a/utmsks.net/material/home/haskell) (2015 年度作成, 2017 年度改訂)
+* [Haskell 入門](https://minoki.github.io/ks-material/haskell/) (2015 年度作成, 2017 年度改訂)
 * [Julia 入門](https://sites.google.com/a/utmsks.net/material/home/language-list/julia) (2015 年度作成)
 * [D 入門](https://sites.google.com/a/utmsks.net/material/home/dlang)
 


### PR DESCRIPTION
リンク先を古いGoogle Pagesから https://minoki.github.io/ks-material/ 以下へ変更。

リンク先は荒田のアカウント (minoki) のJekyllによるGitHub Pagesだが、そのうちutmsksアカウントに移管するべきだろう。